### PR TITLE
Descriptive errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Validator.valid?(%{currency_pair: "EURUSD", foo: 50, num: -50})
 
 ## Changelog
 
+#### `0.11.0`
+
+- Descriptive errors
+
 #### `0.10.0`
 
 - `@behaviour Exvalibur.Validatable` with overridable `custom_validate/1`

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -31,11 +31,27 @@ defmodule Exvalibur.Error do
     %Exvalibur.Error{message: message, reason: reason}
   end
 
+  @doc false
   def exception(reason: %{empty_rule: rule} = reason) do
     message = """
       Empty rule #{inspect(rule)} in call to `Exvalibur.validator!/2`.
 
       The rule must contain either `matches` or `conditions` field.
+    """
+
+    %Exvalibur.Error{message: message, reason: reason}
+  end
+
+  @doc false
+  def exception(reason: %{input: input, rules: rules} = reason) do
+    message = """
+      No `valid?/1` clause matched the input given:
+
+      #{inspect(input, limit: :infinity)}
+
+      Known rules are:
+
+      #{inspect(rules, limit: :infinity)}
     """
 
     %Exvalibur.Error{message: message, reason: reason}


### PR DESCRIPTION
```elixir
with {:error, error} <- CustomValidator.validate(%{foo: 50}, error: :detailed),
  do: error.reason
#⇒ %{
#      input: %{foo: 50},
#      rules: [%{conditions: %{foo: %{max: 10, min: 0}}}]
# }
```